### PR TITLE
Add scikit-image as a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "plotly>=6",
   "requests>=2.32.4",
   "scanpy>=1.10.4,<2",
+  "scikit-image>=0.24",
   "scipy>=1.15.2,<2",
   "session-info2>=0.1,<0.2",
 ]


### PR DESCRIPTION
## Summary
- Adds `scikit-image>=0.24` as an explicit dependency in `pyproject.toml`
- Required for doublet detection: `scanpy.pp.scrublet()` calls `skimage.filters.threshold_minimum` for automatic threshold calculation
- Without this dependency, `--remove_doublets` fails with `ValueError: threshold is None and thus scrublet requires skimage, but skimage is not installed`

## Version constraint rationale
- `>=0.24`: required for numpy 2.x compatibility (QCatch pins `numpy>=2.1.3`)
- Aligns with scanpy's `[scrublet]` extra which requires `scikit-image>=0.23.1`

## Test plan
- [x] Verified `--remove_doublets` fails without `scikit-image` installed
- [x] Confirmed `scikit-image>=0.24` resolves correctly with existing dependency constraints
- [x] Tested QCatch pipeline run with `--remove_doublets --visualize_doublets` flags